### PR TITLE
feat(ui): add ChatGPT clipboard export, robust pod error handling, and custom toast notifications

### DIFF
--- a/api/kubernetes/combined.yaml
+++ b/api/kubernetes/combined.yaml
@@ -32,8 +32,8 @@ metadata:
 spec:
   containers:
     - name: web
-      image: kaiwalyakoparkar/podlogger-web
-      imagePullPolicy: Always
+      image: kaiwalyakoparkar/podlogger-web:v4
+      imagePullPolicy: IfNotPresent
       ports:
       - containerPort: 80
       volumeMounts:

--- a/web/script.js
+++ b/web/script.js
@@ -5,7 +5,33 @@ document.addEventListener('DOMContentLoaded', function () {
     const currentNamespace = document.getElementById('currentNamespace');
     const currentPod = document.getElementById('currentPod');
     const refreshButton = document.getElementById('refreshButton');
+    const askChatGPTButton = document.querySelector('.btn-ask-chatgpt');
     let refreshNs, refreshPod = '';
+
+    // Create toast container if it doesn't exist
+    let toastContainer = document.querySelector('.toast-container');
+    if (!toastContainer) {
+        toastContainer = document.createElement('div');
+        toastContainer.className = 'toast-container';
+        document.body.appendChild(toastContainer);
+    }
+
+    function showToast(message, type = 'success') {
+        const toast = document.createElement('div');
+        toast.className = `toast ${type === 'error' ? 'toast-error' : ''}`;
+
+        const icon = type === 'success'
+            ? '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--orange-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>'
+            : '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ff3333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>';
+
+        toast.innerHTML = `${icon} <span>${message}</span>`;
+        toastContainer.appendChild(toast);
+
+        setTimeout(() => {
+            toast.classList.add('hiding');
+            toast.addEventListener('animationend', () => toast.remove());
+        }, 4000);
+    }
 
     //Fetching Namespaces and processing them for options
     let namespaceData = fetchNamespaces();
@@ -33,8 +59,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
         let podsData = fetchPods(namespace);
         podsData.then(data => {
-            data = JSON.parse(data);
-            // console.log(data);
+            try {
+                data = JSON.parse(data);
+            } catch (e) {
+                throw new Error("Invalid response format");
+            }
+
+            if (!data || !data.items || !Array.isArray(data.items)) {
+                throw new Error(data.message || "Failed to load pods");
+            }
 
             data.items.forEach(pod => {
                 let podElement = document.createElement('div');
@@ -62,18 +95,33 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function showPodLogs(namespace, podName) {
-        container = fetchContainer(namespace, podName);
+        let container = fetchContainer(namespace, podName);
         container.then(data => {
-            data = JSON.parse(data);
-            containerName = data[0];
+            if (!data || data.trim() === "No containers found" || data.trim() === "Error Occured") {
+                throw new Error("No containers found for this pod.");
+            }
+            try {
+                data = JSON.parse(data);
+            } catch (e) {
+                throw new Error("Failed to parse container list.");
+            }
+            let containerName = data[0];
+            if (!containerName) {
+                throw new Error("Container list is empty.");
+            }
             console.log("Using container " + containerName);
             const pod = fetchLogs(namespace, podName, containerName);
-            pod.then(data => {
-                logsContent.textContent = data;
+            pod.then(logData => {
+                logsContent.textContent = logData;
                 refreshNs = namespace;
                 refreshPod = podName;
+            }).catch(error => {
+                logsContent.textContent = "Error fetching logs";
             })
-        })
+        }).catch(error => {
+            logsContent.textContent = error.message || "Error identifying pod container";
+            console.error(error);
+        });
     }
 
     //Fetching pods after receieving selected namespace
@@ -93,6 +141,35 @@ document.addEventListener('DOMContentLoaded', function () {
     //Refresh Button event listener
     refreshButton.addEventListener('click', () => {
         showPodLogs(refreshNs, refreshPod);
+    });
+
+    //Ask ChatGPT Button event listener
+    askChatGPTButton.addEventListener('click', () => {
+        const logs = logsContent.textContent.trim();
+        const ns = currentNamespace.textContent.trim();
+        const pod = currentPod.textContent.trim();
+
+        if (!logs || logs === 'Select a namespace and pod to view logs') {
+            showToast('Please select a pod and load its logs before asking ChatGPT.', 'error');
+            return;
+        }
+
+        const prompt = `I have the following Kubernetes pod logs from namespace "${ns}", pod "${pod}". Please analyze them for errors, warnings, or any issues and suggest fixes:\n\n${logs}`;
+
+        try {
+            navigator.clipboard.writeText(prompt).then(() => {
+                showToast('Logs and prompt copied! Opening ChatGPT...');
+                setTimeout(() => window.open('https://chatgpt.com/', '_blank'), 1500);
+            }).catch(err => {
+                console.error('Clipboard copy failed:', err);
+                showToast('Failed to copy to clipboard. Please copy manually.', 'error');
+            });
+        } catch (err) {
+            console.error('Clipboard API not supported:', err);
+            // Fallback for older browsers or non-HTTPS
+            const encodedPrompt = encodeURIComponent(prompt.substring(0, 1500) + '... (logs truncated)');
+            window.open('https://chatgpt.com/?q=' + encodedPrompt, '_blank');
+        }
     });
 });
 
@@ -143,16 +220,16 @@ async function fetchNamespaces() {
                 'Content-Type': 'application/json'
             }
         });
-        
+
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
-        
+
         const data = await response.json();
         if (!data || !data.env) {
             throw new Error('Invalid response format');
         }
-        
+
         return data.env;
     } catch (error) {
         console.error('Error listing namespaces: ', error);

--- a/web/styles.css
+++ b/web/styles.css
@@ -293,3 +293,65 @@ body {
   outline: 2px solid rgba(129, 60, 0, 0.5);
   outline-offset: 2px;
 }
+
+/* Custom Toast Notification */
+.toast-container {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 9999;
+}
+
+.toast {
+  background: rgba(30, 30, 30, 0.95);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--orange-color);
+  color: var(--text-primary);
+  padding: 16px 24px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 500;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  transform: translateX(120%);
+  opacity: 0;
+  animation: slideInRight 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 300px;
+  max-width: 450px;
+}
+
+.toast.toast-error {
+  border-left-color: #ff3333;
+}
+
+.toast.hiding {
+  animation: slideOutRight 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideOutRight {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Overview
This PR introduces several UI/UX improvements to the Pod Logger dashboard, primarily focusing on making the "Ask ChatGPT" integration robust and replacing generic browser alerts with a modern, animated notification system. It also improves error handling when interacting with the Kubernetes API.

## Key Changes
- **ChatGPT Export via Clipboard API**: Replaced the URL-based prompt export (which failed with `404 Not Found` for long pod logs due to URI length limits) with the native Clipboard API. The prompt is now safely copied to the user's clipboard, and a clean `chatgpt.com` tab is opened for them to paste the logs.
- **Robust JSON Parsing**: Added `try/catch` blocks and structural validation when parsing pod and container data from the backend. This prevents the UI from crashing with `SyntaxError` when the backend returns error strings (e.g., `"No containers found"` or `"Error Occured"`) instead of expected JSON objects.
- **Sleek Toast Notifications**: Removed all generic, blocking `window.alert()` calls. Implemented a custom animated Toast Notification system (in `styles.css` and `script.js`) featuring glassmorphism design, SVG icons, and auto-hiding logic.
- **Minikube Deployment Config**: Updated the Kubernetes manifest (`combined.yaml`) to explicitly tag and pull the new `v4` web image using `imagePullPolicy: IfNotPresent`.

